### PR TITLE
feat(Dependabot): add action for daily Dependabot slack alerts

### DIFF
--- a/.github/workflows/Dependabot-Slack.yml
+++ b/.github/workflows/Dependabot-Slack.yml
@@ -1,8 +1,8 @@
 name: 'Dependabot-Critical-Slack-Alerts'
 
 on:
-  # schedule:
-  #   - cron: '0 0 * * *' # every 6 hours
+  schedule:
+    - cron: '0 0 * * *' # every midnight GMT
   workflow_dispatch:  # Allow manual triggering
 jobs:
   main:
@@ -14,5 +14,5 @@ jobs:
         with:
           token: ${{ secrets.GH_PAT }}
           severity: critical
-          slack_webhook: ${{ secrets.DBOT_SLACK_BOT_TOKEN }}
+          slack_webhook: ${{ secrets.SLACK_VULNERABILITY_ALERTS_TOKEN }}
           count: 20


### PR DESCRIPTION
## Dependabot-Critical-Slack-Alerts Workflow

This workflow uses the `kunalnagarco/action-cve` action to monitor for critical vulnerability alerts from Dependabot and send them to Slack.

### Purpose

The purpose of this workflow is to:

1. Regularly scan for critical vulnerabilities in our dependencies
2. Aggregate the most recent 20 critical vulnerabilities found
3. Send a consolidated alert to our Slack channel

### How It Works

- Runs daily at midnight GMT (configurable)
- Checks for critical vulnerabilities using Dependabot data
- Sends a single Slack message with details of the latest 20 critical vulnerabilities

### Configuration Details

- Uses Dependabot's PAT (`GH_PAT`) for authentication
- Sets severity filter to `critical`
- Configured to send alerts to Slack via webhook (`SLACK_VULNERABILITY_ALERTS_TOKEN`)
- Limited to reporting the most recent 20 critical vulnerabilities

### Benefits

- Proactive security monitoring
- Centralized alerting for critical vulnerabilities
- Easy-to-consume Slack messages for quick triage

### Next Steps

- Review the Slack alerts regularly
- Investigate and address vulnerabilities promptly
- Consider implementing additional automated fixes for known vulnerabilities

### Notes

- This workflow complements existing security practices
- It's designed to work alongside Dependabot's vulnerability reports
- Adjust the `count` parameter if you prefer fewer/more vulnerabilities per alert

Please review and provide feedback on this proposed workflow before merging.
